### PR TITLE
long data json lead to unmashal failure because that reader.read() onle get a part of json.

### DIFF
--- a/api/apiUtil.go
+++ b/api/apiUtil.go
@@ -154,12 +154,11 @@ func GetBodyFromResponse(reader io.ReadCloser) string {
 	strRe := "";
 	temp := make([]byte, bodyCache)
 	byteCount, _ := reader.Read(temp)
-	strRe += byteToString(temp, byteCount)
 
-	for ; byteCount == bodyCache; {
-		tempCycle := make([]byte, bodyCache)
-		byteCount, _ = reader.Read(tempCycle)
+	for ; byteCount > 0; {
 		strRe += byteToString(temp, byteCount)
+		temp = make([]byte, bodyCache)
+		byteCount, _ = reader.Read(temp)
 	}
 	strRe = strings.Trim(strRe, "\"")
 	strRe = strings.Trim(strRe, " ")

--- a/api/network.go
+++ b/api/network.go
@@ -166,7 +166,7 @@ func (network *struNetwork) Get(outputKind string) ([]struNetworkRe, string, err
 	getUrlAll := hostport + "/" + getUriAll
 	response, err := http.Get(getUrlAll)
 	// get all result
-	arr, erro := ExcuteNWResponse(response, getUriAll, http.MethodGet)
+	arr, erro := ExcuteNWResponse(response, getUrlAll, http.MethodGet)
 	if (erro != nil) {
 		return arr, "", erro
 	}


### PR DESCRIPTION
What this PR does / why we need it:

It report a error like "error: unexpected end of JSON input" when get more informations using command "knitctl get". using function reader.read() error, finally only get a part of data when data is more 4096 characters. I changed the implementation of using 'reader.read()'

Fixes #NONE

Special notes for your reviewer:
NONE
Release note:
NONE